### PR TITLE
Correct typos for "termVector"

### DIFF
--- a/examples/schema/brown.conf
+++ b/examples/schema/brown.conf
@@ -20,7 +20,7 @@ schema {
       }
       indexed : true
       stored : true
-      termvector : true
+      termVector : true
       positions : true
     }
     {
@@ -46,7 +46,7 @@ schema {
       }
       indexed : true
       stored : true
-      termvector : true
+      termVector : true
       positions : true
     }
     {

--- a/examples/schema/jawiki.conf
+++ b/examples/schema/jawiki.conf
@@ -12,7 +12,7 @@ schema {
       name : title
       indexed : true
       stored : true
-      termvectors : true
+      termVector : true
       positions : true
     }
     {
@@ -22,7 +22,7 @@ schema {
       }
       indexed : true
       stored : true
-      termvectors : true
+      termVector : true
       positions : true
     }
     {
@@ -32,7 +32,7 @@ schema {
       }
       indexed : true
       stored : true
-      termvectors : true
+      termVector : true
       positions : true
     }
     {
@@ -42,14 +42,14 @@ schema {
       }
       indexed : true
       stored : true
-      termvectors : true
+      termVector : true
       positions : true
     }
     {
       name : cat
       indexed : true
       stored : true
-      termvectors : true
+      termVector : true
       positions : true
     }
     {
@@ -59,7 +59,7 @@ schema {
       }
       indexed : true
       stored : true
-      termvectors : true
+      termVector : true
       positions : true
     }
   ]

--- a/examples/schema/reuters.conf
+++ b/examples/schema/reuters.conf
@@ -35,7 +35,7 @@ schema {
       }
       indexed : true
       stored : true
-      termvector : true
+      termVector : true
       positions : true
     }
     {
@@ -45,7 +45,7 @@ schema {
       }
       indexed : true
       stored : true
-      termvector : true
+      termVector : true
       positions : true
     }
     {
@@ -55,7 +55,7 @@ schema {
       }
       indexed : true
       stored : true
-      termvector : true
+      termVector : true
       positions : true
     }
     {
@@ -65,7 +65,7 @@ schema {
       }
       indexed : true
       stored : true
-      termvector : true
+      termVector : true
       positions : true
     }
     {
@@ -75,7 +75,7 @@ schema {
       }
       indexed : true
       stored : true
-      termvector : true
+      termVector : true
       positions : true
     }
     {
@@ -85,7 +85,7 @@ schema {
       }
       indexed : true
       stored : true
-      termvector : true
+      termVector : true
       positions : true
     }
     {
@@ -95,7 +95,7 @@ schema {
       }
       indexed : true
       stored : true
-      termvector : true
+      termVector : true
       positions : true
     }
     {
@@ -105,7 +105,7 @@ schema {
       }
       indexed : true
       stored : true
-      termvector : true
+      termVector : true
       positions : true
     }
     {
@@ -115,7 +115,7 @@ schema {
       }
       indexed : true
       stored : true
-      termvector : true
+      termVector : true
       positions : true
     }
     {
@@ -125,7 +125,7 @@ schema {
       }
       indexed : true
       stored : true
-      termvector : true
+      termVector : true
       positions : true
     }
   ]


### PR DESCRIPTION
Use "termVector" attribute in schema files to store term vectors.
(Maybe we need some sort of schema validation...)
